### PR TITLE
add support for nf private api secret in header

### DIFF
--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -24,6 +24,7 @@ class Flush: AppLifecycle {
     var flushRequest: FlushRequest
     var flushOnBackground = true
     var _flushInterval = 0.0
+    var apiKey: String? = nil
     var appToken: String? = nil
 
     private let flushIntervalReadWriteLock: DispatchQueue
@@ -110,6 +111,7 @@ class Flush: AppLifecycle {
                 flushRequest.sendRequest(requestData,
                                          type: type,
                                          useIP: useIPAddressForGeoLocation,
+                                         apiKey: apiKey,
                                          appToken: appToken,
                                          completion: { [weak self, semaphore] success in
                                             guard let self = self else { return }

--- a/Sources/FlushRequest.swift
+++ b/Sources/FlushRequest.swift
@@ -22,6 +22,7 @@ class FlushRequest: Network {
     func sendRequest(_ requestData: String,
                      type: FlushType,
                      useIP: Bool,
+                     apiKey: String? = nil,
                      appToken: String? = nil,
                      completion: @escaping (Bool) -> Void) {
 
@@ -37,6 +38,9 @@ class FlushRequest: Network {
             .data(using: String.Encoding.utf8)
 
         var headers = ["Accept-Encoding": "gzip"]
+        if let apiKey = apiKey {
+            headers["nf-api"] = apiKey
+        }
         if let appToken = appToken {
             headers["Authorization"] = "Bearer \(appToken)"
         }

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -48,6 +48,13 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     /// apiToken string that identifies the project to track data to
     open var apiToken = ""
 
+    /// Additional key to be added to request headers as Authorization
+    open var apiKey = "" {
+        didSet {
+            flushInstance.apiKey = apiKey
+        }
+    }
+
     /// Additional token to be added to request headers as Authorization
     open var appToken = "" {
         didSet {


### PR DESCRIPTION
allow an app to provide our private api secret to be added to the header.

even though it's static I'm using a var so we don't have to thread it through the initializers. maybe we change it to a generic "additional headers" config later.